### PR TITLE
Make links domain-relative

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,10 +1,10 @@
 <header class="site-header">
 
-  <a href="{{ site.github.url }}/" class="site-logo">
+  <a href="/" class="site-logo">
     <h1>
       <img
         class="site-logo-img"
-        src="{{ site.github.url }}/assets/images/uacf_logo.png"
+        src="/assets/images/uacf_logo.png"
         alt="Under Armour Connected Fitness"
       />
     </h1>
@@ -12,7 +12,7 @@
 
   <div class="site-nav-button">
     <span class="site-nav-button-text">Menu</span>
-    <img class="site-nav-button-icon" src="{{ site.github.url }}/assets/images/menu.svg" alt="" height="20" width="20">
+    <img class="site-nav-button-icon" src="/assets/images/menu.svg" alt="" height="20" width="20">
   </div>
 
   <nav class="site-nav">
@@ -21,14 +21,14 @@
         <div class="site-nav-dropdown">
           <button class="site-nav-dropbtn">DOCS</button>
           <div class="site-nav-dropdown-content">
-            <a href="{{ site.github.url }}/docs">UACF</a>
-            <a href="{{ site.github.url }}/docs-mfp">MyFitnessPal</a>
+            <a href="/docs">UACF</a>
+            <a href="/docs-mfp">MyFitnessPal</a>
           </div>
         </div>
       </li>
-      <li class="site-nav-item signup"><a href="{{ site.github.url }}/signup">Request a Key</a></li>
-      <li class="site-nav-item updatekey"><a href="{{ site.github.url }}/updatekey">Update your Key</a></li>
-      <li class="site-nav-item blog"><a href="{{ site.github.url }}/blog">Blog</a></li>
+      <li class="site-nav-item signup"><a href="/signup">Request a Key</a></li>
+      <li class="site-nav-item updatekey"><a href="/updatekey">Update your Key</a></li>
+      <li class="site-nav-item blog"><a href="/blog">Blog</a></li>
     </ul>
   </nav>
 

--- a/_includes/mfp_sidenav.html
+++ b/_includes/mfp_sidenav.html
@@ -1,111 +1,111 @@
 <div class="sidenav">
 
   <h3>Architecture</h3>
-  <a href="{{ site.github.url }}/docs-mpf/about">About this API</a>
-  <a href="{{ site.github.url }}/docs-mpf/domains">Domains</a>
-  <a href="{{ site.github.url }}/docs-mpf/versioning">Versioning</a>
-  <a href="{{ site.github.url }}/docs-mpf/example-urls">Example URLs</a>
+  <a href="/docs-mpf/about">About this API</a>
+  <a href="/docs-mpf/domains">Domains</a>
+  <a href="/docs-mpf/versioning">Versioning</a>
+  <a href="/docs-mpf/example-urls">Example URLs</a>
   <h3>General</h3>
-  <a href="{{ site.github.url }}/docs-mpf/identifiers">Identifiers</a>
-  <a href="{{ site.github.url }}/docs-mpf/supported-data-formats">Supported Data Formats</a>
-  <a href="{{ site.github.url }}/docs-mpf/data-types">Data Types</a>  
+  <a href="/docs-mpf/identifiers">Identifiers</a>
+  <a href="/docs-mpf/supported-data-formats">Supported Data Formats</a>
+  <a href="/docs-mpf/data-types">Data Types</a>  
   <h5>Requests</h5>
-    <a href="{{ site.github.url }}/docs-mpf/access-tokens">Access Token and Related Information</a>
-    <a href="{{ site.github.url }}/docs-mpf/localization">Localization</a>
-    <a href="{{ site.github.url }}/docs-mpf/get-request-query-param">GET Request Query Parameter</a>
-    <a href="{{ site.github.url }}/docs-mpf/collection-requests">Collection Requests</a>
-    <a href="{{ site.github.url }}/docs-mpf/post-patch-request">POST/PATCH Request Body</a>
+    <a href="/docs-mpf/access-tokens">Access Token and Related Information</a>
+    <a href="/docs-mpf/localization">Localization</a>
+    <a href="/docs-mpf/get-request-query-param">GET Request Query Parameter</a>
+    <a href="/docs-mpf/collection-requests">Collection Requests</a>
+    <a href="/docs-mpf/post-patch-request">POST/PATCH Request Body</a>
   <h5>Responses</h5>
-    <a href="{{ site.github.url }}/docs-mpf/content-type">Content Type</a>
-    <a href="{{ site.github.url }}/docs-mpf/response-codes">Response Codes</a>
-    <a href="{{ site.github.url }}/docs-mpf/response-body">Response Body</a>
-    <a href="{{ site.github.url }}/docs-mpf/error-responses">Error Responses</a>
-    <a href="{{ site.github.url }}/docs-mpf/standard-responses">Standard Responses</a>
+    <a href="/docs-mpf/content-type">Content Type</a>
+    <a href="/docs-mpf/response-codes">Response Codes</a>
+    <a href="/docs-mpf/response-body">Response Body</a>
+    <a href="/docs-mpf/error-responses">Error Responses</a>
+    <a href="/docs-mpf/standard-responses">Standard Responses</a>
   <h3>Authentication and Authorization</h3>  
-    <a href="{{ site.github.url }}/docs-mpf/partner-authentication">Partner Authentication</a>
-    <a href="{{ site.github.url }}/docs-mpf/user-authentication">User Authorization</a>
+    <a href="/docs-mpf/partner-authentication">Partner Authentication</a>
+    <a href="/docs-mpf/user-authentication">User Authorization</a>
     <h5>Authorization Code Grant (GET /oauth2/auth)</h5>
-      <a href="{{ site.github.url }}/docs-mpf/request-query-parameters">Request query parameters</a>
-      <a href="{{ site.github.url }}/docs-mpf/auth-example-1">Example 1: Requesting the diary scope</a>
-      <a href="{{ site.github.url }}/docs-mpf/auth-example-2">Example 2: Requesting all available scopes</a>
-      <a href="{{ site.github.url }}/docs-mpf/auth-response">Response</a>
-      <a href="{{ site.github.url }}/docs-mpf/auth-errors">Authorization Errors</a>
+      <a href="/docs-mpf/request-query-parameters">Request query parameters</a>
+      <a href="/docs-mpf/auth-example-1">Example 1: Requesting the diary scope</a>
+      <a href="/docs-mpf/auth-example-2">Example 2: Requesting all available scopes</a>
+      <a href="/docs-mpf/auth-response">Response</a>
+      <a href="/docs-mpf/auth-errors">Authorization Errors</a>
     <h5>Access Token Request (POST /oauth2/token)</h5>
-      <a href="{{ site.github.url }}/docs-mpf/request-body-form-parameters">Request body form parameters</a>
-      <a href="{{ site.github.url }}/docs-mpf/post-response">Response</a>
-      <a href="{{ site.github.url }}/docs-mpf/access-token-errors">Access Token Errors</a>
+      <a href="/docs-mpf/request-body-form-parameters">Request body form parameters</a>
+      <a href="/docs-mpf/post-response">Response</a>
+      <a href="/docs-mpf/access-token-errors">Access Token Errors</a>
     <h5>Refreshing Access Tokens (POST /oauth2/token)</h5>
-      <a href="{{ site.github.url }}/docs-mpf/refresh-request-body-form-parameters">Request body form parameters</a>
-      <a href="{{ site.github.url }}/docs-mpf/refresh-post-response">Response</a>
-      <a href="{{ site.github.url }}/docs-mpf/refresh-token-errors">Refresh Token Errors</a>
-    <a href="{{ site.github.url }}/docs-mpf/making-requests">Making Requests</a>    
+      <a href="/docs-mpf/refresh-request-body-form-parameters">Request body form parameters</a>
+      <a href="/docs-mpf/refresh-post-response">Response</a>
+      <a href="/docs-mpf/refresh-token-errors">Refresh Token Errors</a>
+    <a href="/docs-mpf/making-requests">Making Requests</a>    
     <h5>Revoking Tokens (POST /oauth2/revoke)</h5>
-      <a href="{{ site.github.url }}/docs-mpf/revoke-request-body-form-parameters">Request body form parameters</a>
-      <a href="{{ site.github.url }}/docs-mpf/revoke-response">Response</a>
+      <a href="/docs-mpf/revoke-request-body-form-parameters">Request body form parameters</a>
+      <a href="/docs-mpf/revoke-response">Response</a>
   <h3>Users</h3>  
     <h5>Resources GET /users/:userId</h5>
-      <a href="{{ site.github.url }}/docs-mpf/example-response-no-fields-parameter">Example Response with no fields parameter</a>
-      <a href="{{ site.github.url }}/docs-mpf/example-response-with-fields-parameter">Example Response with fields elements</a>
+      <a href="/docs-mpf/example-response-no-fields-parameter">Example Response with no fields parameter</a>
+      <a href="/docs-mpf/example-response-with-fields-parameter">Example Response with fields elements</a>
     <h5>Resources PATCH /users/:userId</h5>
-      <a href="{{ site.github.url }}/docs-mpf/patch-request-example">Request Example</a>
+      <a href="/docs-mpf/patch-request-example">Request Example</a>
   <h3>Measurements</h3>
     <h5>Resources</h5>
-      <a href="{{ site.github.url }}/docs-mpf/measurements-get">GET /measurements/</a>
-      <a href="{{ site.github.url }}/docs-mpf/measurements-post">POST /measurements/</a>
+      <a href="/docs-mpf/measurements-get">GET /measurements/</a>
+      <a href="/docs-mpf/measurements-post">POST /measurements/</a>
   
   <h3>Diary</h3>    
     <h5>Resources</h5>
-      <a href="{{ site.github.url }}/docs-mpf/diary-get">GET /diary/</a>
-      <a href="{{ site.github.url }}/docs-mpf/diary-post">POST /diary/</a>
-      <a href="{{ site.github.url }}/docs-mpf/diary-patch">PATCH /diary/</a>
-      <a href="{{ site.github.url }}/docs-mpf/diary-delete">DELETE /diary/</a>
+      <a href="/docs-mpf/diary-get">GET /diary/</a>
+      <a href="/docs-mpf/diary-post">POST /diary/</a>
+      <a href="/docs-mpf/diary-patch">PATCH /diary/</a>
+      <a href="/docs-mpf/diary-delete">DELETE /diary/</a>
   <h3>Exercises</h3>    
     <h5>Resources</h5>
-      <a href="{{ site.github.url }}/docs-mpf/exercises-diary-get">GET /exercises/</a>
+      <a href="/docs-mpf/exercises-diary-get">GET /exercises/</a>
   <h3>Subscriptions</h3>    
     <h5>Management</h5>
-      <a href="{{ site.github.url }}/docs-mpf/subscription-post">POST /subscription/</a>
-      <a href="{{ site.github.url }}/docs-mpf/subscription-get">GET /subscription/</a>      
-      <a href="{{ site.github.url }}/docs-mpf/subscription-patch">PATCH /subscription/</a>
-      <a href="{{ site.github.url }}/docs-mpf/subscription-delete">DELETE /subscription/</a>
+      <a href="/docs-mpf/subscription-post">POST /subscription/</a>
+      <a href="/docs-mpf/subscription-get">GET /subscription/</a>      
+      <a href="/docs-mpf/subscription-patch">PATCH /subscription/</a>
+      <a href="/docs-mpf/subscription-delete">DELETE /subscription/</a>
     <h5>Notifications</h5>
-      <a href="{{ site.github.url }}/docs-mpf/subscription-request-body">Example Request Body</a>
-      <a href="{{ site.github.url }}/docs-mpf/subscription-design">Best Design Practices</a>
+      <a href="/docs-mpf/subscription-request-body">Example Request Body</a>
+      <a href="/docs-mpf/subscription-design">Best Design Practices</a>
   <h3>Appendix</h3>    
     <h5>Data Structures</h5>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-data-structures-user">User</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-data-structures-measured-value">Measured Value</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-data-structures-user-profile">User Profile</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-data-structures-account">Account</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-data-structures-privacy-preferences">Privacy Preferences</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-data-structures-goal-preferences">Goal Preferences</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-data-structures-location-preferences">Location Preferences</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-data-structures-diary-preferences">Diary Preferences</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-data-structures-nutritional-contents">Nutritional Contents</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-data-structures-exercise">Exercise</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-data-structures-measurement">Measurement</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-data-structures-diary">Diary</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-data-structures-subscription">Subscription</a>
+      <a href="/docs-mpf/appendix-data-structures-user">User</a>
+      <a href="/docs-mpf/appendix-data-structures-measured-value">Measured Value</a>
+      <a href="/docs-mpf/appendix-data-structures-user-profile">User Profile</a>
+      <a href="/docs-mpf/appendix-data-structures-account">Account</a>
+      <a href="/docs-mpf/appendix-data-structures-privacy-preferences">Privacy Preferences</a>
+      <a href="/docs-mpf/appendix-data-structures-goal-preferences">Goal Preferences</a>
+      <a href="/docs-mpf/appendix-data-structures-location-preferences">Location Preferences</a>
+      <a href="/docs-mpf/appendix-data-structures-diary-preferences">Diary Preferences</a>
+      <a href="/docs-mpf/appendix-data-structures-nutritional-contents">Nutritional Contents</a>
+      <a href="/docs-mpf/appendix-data-structures-exercise">Exercise</a>
+      <a href="/docs-mpf/appendix-data-structures-measurement">Measurement</a>
+      <a href="/docs-mpf/appendix-data-structures-diary">Diary</a>
+      <a href="/docs-mpf/appendix-data-structures-subscription">Subscription</a>
     <h5>Error Codes</h5>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-error-codes">Error Codes</a>
+      <a href="/docs-mpf/appendix-error-codes">Error Codes</a>
     <h5>Migrating from MyFitnessPal API v1 to v2</h5>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-migrate-log_cardio_exercise">v1 action: log_cardio_exercise</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-migrate-remove_cardio_exercise">v1 action: remove_cardio_exercise</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-migrate-log_weight">v1 action: log_weight</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-migrate-log_expended_energy">v1 action: log_expended_energy</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-migrate-get_food_summary">v1 action: get_food_summary</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-migrate-get_cardio_exercises">v1 action: get_cardio_exercises</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-migrate-get_weight">v1 action: get_weight</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-migrate-fetch_user_info">v1 action: fetch_user_info</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-migrate-subscribe_to_user_updates">v1 action: subscribe_to_user_updates</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-migrate-unsubscribe_from_user_updates">v1 action: unsubscribe_from_user_updates</a>
+      <a href="/docs-mpf/appendix-migrate-log_cardio_exercise">v1 action: log_cardio_exercise</a>
+      <a href="/docs-mpf/appendix-migrate-remove_cardio_exercise">v1 action: remove_cardio_exercise</a>
+      <a href="/docs-mpf/appendix-migrate-log_weight">v1 action: log_weight</a>
+      <a href="/docs-mpf/appendix-migrate-log_expended_energy">v1 action: log_expended_energy</a>
+      <a href="/docs-mpf/appendix-migrate-get_food_summary">v1 action: get_food_summary</a>
+      <a href="/docs-mpf/appendix-migrate-get_cardio_exercises">v1 action: get_cardio_exercises</a>
+      <a href="/docs-mpf/appendix-migrate-get_weight">v1 action: get_weight</a>
+      <a href="/docs-mpf/appendix-migrate-fetch_user_info">v1 action: fetch_user_info</a>
+      <a href="/docs-mpf/appendix-migrate-subscribe_to_user_updates">v1 action: subscribe_to_user_updates</a>
+      <a href="/docs-mpf/appendix-migrate-unsubscribe_from_user_updates">v1 action: unsubscribe_from_user_updates</a>
     <h5>Tracking all­day steps activity</h5>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-tracking-all-day-steps">Tracking all-day steps activity</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-tracking-recommended-approach">Recommended approach for tracking steps</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-tracking-determining-daily-totals">Determining daily totals</a>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-tracking-calorie-adjustments">Calorie Adjustments</a>
+      <a href="/docs-mpf/appendix-tracking-all-day-steps">Tracking all-day steps activity</a>
+      <a href="/docs-mpf/appendix-tracking-recommended-approach">Recommended approach for tracking steps</a>
+      <a href="/docs-mpf/appendix-tracking-determining-daily-totals">Determining daily totals</a>
+      <a href="/docs-mpf/appendix-tracking-calorie-adjustments">Calorie Adjustments</a>
     <h5>MyFitnessPal exercises and their identifiers</h5>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-mfp-exercises-identifiers">MyFitnessPal exercises and their identifiers</a>
+      <a href="/docs-mpf/appendix-mfp-exercises-identifiers">MyFitnessPal exercises and their identifiers</a>
     <h5>Full request and response examples</h5>
-      <a href="{{ site.github.url }}/docs-mpf/appendix-full-request-examples">POST and GET request and response</a>
+      <a href="/docs-mpf/appendix-full-request-examples">POST and GET request and response</a>
 </div>

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,30 +1,30 @@
 <div class="sidenav">
 
   <h3>Getting Started</h3>
-  <a href="{{ site.github.url }}/signup">Request a Key</a>
-  <a href="{{ site.github.url }}/updatekey">Update your Key</a>    
-  <a href="{{ site.github.url }}/faq">FAQ</a>
-  <a href="{{ site.github.url }}/docs/v70_Release_Notes">Release Notes</a>
+  <a href="/signup">Request a Key</a>
+  <a href="/updatekey">Update your Key</a>    
+  <a href="/faq">FAQ</a>
+  <a href="/docs/v70_Release_Notes">Release Notes</a>
 
   <h3>Overview</h3>
-  <a href="{{ site.github.url }}/docs/v71_workouts_and_24_7_tracking">Workouts &amp; 24/7 Tracking</a>
-  <a href="{{ site.github.url }}/docs/v70_Authentication">Authentication</a>
-  <a href="{{ site.github.url }}/docs/v71_actigraphy_vs_aggregate">Actigraphy vs. Aggregate</a>
+  <a href="/docs/v71_workouts_and_24_7_tracking">Workouts &amp; 24/7 Tracking</a>
+  <a href="/docs/v70_Authentication">Authentication</a>
+  <a href="/docs/v71_actigraphy_vs_aggregate">Actigraphy vs. Aggregate</a>
 
   <h3>Tutorials</h3>
-  <a href="{{ site.github.url }}/docs/v71_OAuth_2_Intro">Intro to OAuth 2</a>
-  <a href="{{ site.github.url }}/docs/v71_OAuth_2_Demo">OAuth 2 Tutorial</a>
-  <a href="{{ site.github.url }}/docs/v71_OAuth_2_Client_Creds">OAuth 2 Client Credentials</a>
-  <a href="{{ site.github.url }}/docs/v71_24_7_tracking_tutorial">24/7 Tracking: Writing</a>
-  <a href="{{ site.github.url }}/docs/v71_24_7_tracking_reading_tutorial">24/7 Tracking: Reading</a>
+  <a href="/docs/v71_OAuth_2_Intro">Intro to OAuth 2</a>
+  <a href="/docs/v71_OAuth_2_Demo">OAuth 2 Tutorial</a>
+  <a href="/docs/v71_OAuth_2_Client_Creds">OAuth 2 Client Credentials</a>
+  <a href="/docs/v71_24_7_tracking_tutorial">24/7 Tracking: Writing</a>
+  <a href="/docs/v71_24_7_tracking_reading_tutorial">24/7 Tracking: Reading</a>
 
   <h3>References</h3>
-  <a href="{{ site.github.url }}/versioning_policy">Versioning Policy</a>
-  <a href="{{ site.github.url }}/docs/v71_Compression">Compression</a>
-  <a href="{{ site.github.url }}/docs/v71_Errors">Errors</a>
-  <a href="{{ site.github.url }}/docs/v71_Paging">Paging</a>
-  <a href="{{ site.github.url }}/docs/v71_Response_Codes">Response Codes</a>
-  <a href="{{ site.github.url }}/docs/v71_Units">Units</a>
+  <a href="/versioning_policy">Versioning Policy</a>
+  <a href="/docs/v71_Compression">Compression</a>
+  <a href="/docs/v71_Errors">Errors</a>
+  <a href="/docs/v71_Paging">Paging</a>
+  <a href="/docs/v71_Response_Codes">Response Codes</a>
+  <a href="/docs/v71_Units">Units</a>
 
   <h3>Resources</h3>
   <div class="resources_v71">{% include sidenav_v71.html %}</div>

--- a/_includes/sidenav_v70.html
+++ b/_includes/sidenav_v70.html
@@ -1,48 +1,48 @@
 <h5>user</h5>
-<a data-released="2015-06-10" data-modified="2015-06-10" data-plans="" href="{{ site.github.url }}/docs/v70_OAuth_2">OAuth 2 Grants</a>
-<a data-released="2014-11-22" data-modified="2014-11-22" data-plans="" href="{{ site.github.url }}/docs/v70_Privacy_Option">Privacy</a>
-<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="{{ site.github.url }}/docs/v70_User">User</a>
-<a data-released="2013-09-30" data-modified="2013-09-30" data-plans="" href="{{ site.github.url }}/docs/v70_User_Profile_Photo">User Profile Photo</a>
-<a data-released="2014-11-17" data-modified="2014-11-17" data-plans="" href="{{ site.github.url }}/docs/v70_User_Role">User Role</a>
-<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="{{ site.github.url }}/docs/v70_User_Stats">User Stats</a>
+<a data-released="2015-06-10" data-modified="2015-06-10" data-plans="" href="/docs/v70_OAuth_2">OAuth 2 Grants</a>
+<a data-released="2014-11-22" data-modified="2014-11-22" data-plans="" href="/docs/v70_Privacy_Option">Privacy</a>
+<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="/docs/v70_User">User</a>
+<a data-released="2013-09-30" data-modified="2013-09-30" data-plans="" href="/docs/v70_User_Profile_Photo">User Profile Photo</a>
+<a data-released="2014-11-17" data-modified="2014-11-17" data-plans="" href="/docs/v70_User_Role">User Role</a>
+<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="/docs/v70_User_Stats">User Stats</a>
 
 <h5>social</h5>
-<a data-released="2014-11-18" data-modified="2014-11-18" data-plans="" href="{{ site.github.url }}/docs/v70_Activity_Story">Activity Story</a>
-<a data-released="2013-09-30" data-modified="2013-09-30" data-plans="" href="{{ site.github.url }}/docs/v70_Friendship">Friendship</a>
-<a data-released="2014-09-23" data-modified="2014-12-17" data-plans="" href="{{ site.github.url }}/docs/v70_Moderation_Action">Moderation Action</a>
-<a data-released="2014-09-23" data-modified="2014-12-17" data-plans="" href="{{ site.github.url }}/docs/v70_Moderation_Action_Type">Moderation Action Type</a>
-<a data-released="2014-09-23" data-modified="2014-12-17" data-plans="" href="{{ site.github.url }}/docs/v70_Moderation_Status">Moderation Status</a>
-<a data-released="2014-12-16" data-modified="2014-12-16" data-plans="" href="{{ site.github.url }}/docs/v70_Page">Page</a>
-<a data-released="2014-12-16" data-modified="2014-12-16" data-plans="" href="{{ site.github.url }}/docs/v70_Page_Association">Page Association</a>
-<a data-released="2014-12-16" data-modified="2014-12-16" data-plans="" href="{{ site.github.url }}/docs/v70_Page_Follow">Page Follow</a>
-<a data-released="2014-12-16" data-modified="2014-12-16" data-plans="" href="{{ site.github.url }}/docs/v70_Page_Type">Page Type</a>
-<a data-released="2014-11-17" data-modified="2014-11-17" data-plans="" href="{{ site.github.url }}/docs/v70_Role">Role</a>
+<a data-released="2014-11-18" data-modified="2014-11-18" data-plans="" href="/docs/v70_Activity_Story">Activity Story</a>
+<a data-released="2013-09-30" data-modified="2013-09-30" data-plans="" href="/docs/v70_Friendship">Friendship</a>
+<a data-released="2014-09-23" data-modified="2014-12-17" data-plans="" href="/docs/v70_Moderation_Action">Moderation Action</a>
+<a data-released="2014-09-23" data-modified="2014-12-17" data-plans="" href="/docs/v70_Moderation_Action_Type">Moderation Action Type</a>
+<a data-released="2014-09-23" data-modified="2014-12-17" data-plans="" href="/docs/v70_Moderation_Status">Moderation Status</a>
+<a data-released="2014-12-16" data-modified="2014-12-16" data-plans="" href="/docs/v70_Page">Page</a>
+<a data-released="2014-12-16" data-modified="2014-12-16" data-plans="" href="/docs/v70_Page_Association">Page Association</a>
+<a data-released="2014-12-16" data-modified="2014-12-16" data-plans="" href="/docs/v70_Page_Follow">Page Follow</a>
+<a data-released="2014-12-16" data-modified="2014-12-16" data-plans="" href="/docs/v70_Page_Type">Page Type</a>
+<a data-released="2014-11-17" data-modified="2014-11-17" data-plans="" href="/docs/v70_Role">Role</a>
 
 <h5>workouts</h5>
-<a data-released="2013-09-30" data-modified="2013-09-30" data-plans="" href="{{ site.github.url }}/docs/v70_Course">Course</a>
-<a data-released="2015-01-01" data-modified="2015-01-01" data-plans="" href="{{ site.github.url }}/docs/v70_DataSource">Data Source</a>
-<a data-released="2015-02-18" data-modified="2015-02-18" data-plans="" href="{{ site.github.url }}/docs/v70_Data_Source_Priority">Data Source Priority</a>
-<a data-released="2015-01-01" data-modified="2015-01-01" data-plans="" href="{{ site.github.url }}/docs/v70_Device">Device</a>
-<a data-released="2014-12-09" data-modified="2014-12-09" data-plans="" href="{{ site.github.url }}/docs/v70_Heart_Rate_Zone">Heart Rate Zone</a>
-<a data-released="2014-12-12" data-modified="2014-12-12" data-plans="" href="{{ site.github.url }}/docs/v70_Heart_Rate_Zone_Calculation">Heart Rate Zone Calculation</a>
-<a data-released="2014-10-31" data-modified="2014-10-31" data-plans="" href="{{ site.github.url }}/docs/v70_Map_Marker_Image">Map Marker Image</a>
-<a data-released="2014-12-15" data-modified="2014-12-15" data-plans="" href="{{ site.github.url }}/docs/v70_Remote_Connection">Remote Connection</a>
-<a data-released="2014-12-15" data-modified="2014-12-15" data-plans="" href="{{ site.github.url }}/docs/v70_Remote_Connection_Type">Remote Connection Type</a>
-<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="{{ site.github.url }}/docs/v70_Route">Route</a>
-<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="{{ site.github.url }}/docs/v70_Route_Bookmark">Route Bookmark</a>
-<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="{{ site.github.url }}/docs/v70_User_Achievement">User Achievement</a>
-<a data-released="2013-10-09" data-modified="2013-10-09" data-plans="" href="{{ site.github.url }}/docs/v70_Workout">Workout</a>
-<a data-released="2014-12-09" data-modified="2014-12-09" data-plans="" href="{{ site.github.url }}/docs/v70_Workout_Heart_Rate">Workout Heart Rate</a>
+<a data-released="2013-09-30" data-modified="2013-09-30" data-plans="" href="/docs/v70_Course">Course</a>
+<a data-released="2015-01-01" data-modified="2015-01-01" data-plans="" href="/docs/v70_DataSource">Data Source</a>
+<a data-released="2015-02-18" data-modified="2015-02-18" data-plans="" href="/docs/v70_Data_Source_Priority">Data Source Priority</a>
+<a data-released="2015-01-01" data-modified="2015-01-01" data-plans="" href="/docs/v70_Device">Device</a>
+<a data-released="2014-12-09" data-modified="2014-12-09" data-plans="" href="/docs/v70_Heart_Rate_Zone">Heart Rate Zone</a>
+<a data-released="2014-12-12" data-modified="2014-12-12" data-plans="" href="/docs/v70_Heart_Rate_Zone_Calculation">Heart Rate Zone Calculation</a>
+<a data-released="2014-10-31" data-modified="2014-10-31" data-plans="" href="/docs/v70_Map_Marker_Image">Map Marker Image</a>
+<a data-released="2014-12-15" data-modified="2014-12-15" data-plans="" href="/docs/v70_Remote_Connection">Remote Connection</a>
+<a data-released="2014-12-15" data-modified="2014-12-15" data-plans="" href="/docs/v70_Remote_Connection_Type">Remote Connection Type</a>
+<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="/docs/v70_Route">Route</a>
+<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="/docs/v70_Route_Bookmark">Route Bookmark</a>
+<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="/docs/v70_User_Achievement">User Achievement</a>
+<a data-released="2013-10-09" data-modified="2013-10-09" data-plans="" href="/docs/v70_Workout">Workout</a>
+<a data-released="2014-12-09" data-modified="2014-12-09" data-plans="" href="/docs/v70_Workout_Heart_Rate">Workout Heart Rate</a>
 
 <h5>24/7</h5>
-<a data-released="2015-03-26" data-modified="2015-03-26" data-plans="" href="{{ site.github.url }}/docs/v70_Actigraphy">Actigraphy</a>
-<a data-released="2013-09-30" data-modified="2013-09-30" data-plans="" href="{{ site.github.url }}/docs/v70_Activity_Type">Activity Type</a>
-<a data-released="2014-10-30" data-modified="2014-10-30" data-plans="" href="{{ site.github.url }}/docs/v70_Aggregate">Aggregate</a>
-<a data-released="2015-03-08" data-modified="2015-03-08" data-plans="" href="{{ site.github.url }}/docs/v70_All_Day_Activity_Time_Series">All Day Activity Time Series</a>
-<a data-released="2015-03-08" data-modified="2015-03-08" data-plans="" href="{{ site.github.url }}/docs/v70_All_Day_Activity">All Day Activity</a>
-<a data-released="2015-01-22" data-modified="2015-01-22" data-plans="" href="{{ site.github.url }}/docs/v70_BodyMass">Body Mass</a>
-<a data-released="2015-01-22" data-modified="2015-01-22" data-plans="" href="{{ site.github.url }}/docs/v70_Sleep">Sleep</a>
+<a data-released="2015-03-26" data-modified="2015-03-26" data-plans="" href="/docs/v70_Actigraphy">Actigraphy</a>
+<a data-released="2013-09-30" data-modified="2013-09-30" data-plans="" href="/docs/v70_Activity_Type">Activity Type</a>
+<a data-released="2014-10-30" data-modified="2014-10-30" data-plans="" href="/docs/v70_Aggregate">Aggregate</a>
+<a data-released="2015-03-08" data-modified="2015-03-08" data-plans="" href="/docs/v70_All_Day_Activity_Time_Series">All Day Activity Time Series</a>
+<a data-released="2015-03-08" data-modified="2015-03-08" data-plans="" href="/docs/v70_All_Day_Activity">All Day Activity</a>
+<a data-released="2015-01-22" data-modified="2015-01-22" data-plans="" href="/docs/v70_BodyMass">Body Mass</a>
+<a data-released="2015-01-22" data-modified="2015-01-22" data-plans="" href="/docs/v70_Sleep">Sleep</a>
 
 <h5>content</h5>
-<a data-released="2015-04-07" data-modified="2015-04-07" data-plans="" href="{{ site.github.url }}/docs/v70_Image">Image</a>
-<a data-released="2014-09-30" data-modified="2014-09-30" data-plans="" href="{{ site.github.url }}/docs/v70_Webhook">Webhook</a>
+<a data-released="2015-04-07" data-modified="2015-04-07" data-plans="" href="/docs/v70_Image">Image</a>
+<a data-released="2014-09-30" data-modified="2014-09-30" data-plans="" href="/docs/v70_Webhook">Webhook</a>

--- a/_includes/sidenav_v71.html
+++ b/_includes/sidenav_v71.html
@@ -1,52 +1,52 @@
 <h5>user</h5>
-<a data-released="2015-06-10" data-modified="2015-06-10" data-plans="" href="{{ site.github.url }}/docs/v71_OAuth_2">OAuth 2 Grants</a>
-<a data-released="2015-04-07" data-modified="2015-04-07" data-plans="" href="{{ site.github.url }}/docs/v71_OAuth2ConnectionRevokeResource">OAuth 2 Revoke</a>
-<a data-released="2014-11-22" data-modified="2014-11-22" data-plans="" href="{{ site.github.url }}/docs/v71_Privacy_Option">Privacy</a>
-<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="{{ site.github.url }}/docs/v71_User">User</a>
-<a data-released="2013-09-30" data-modified="2013-09-30" data-plans="" href="{{ site.github.url }}/docs/v71_User_Profile_Photo">User Profile Photo</a>
-<a data-released="2014-11-17" data-modified="2014-11-17" data-plans="" href="{{ site.github.url }}/docs/v71_User_Role">User Role</a>
-<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="{{ site.github.url }}/docs/v71_User_Stats">User Stats</a>
+<a data-released="2015-06-10" data-modified="2015-06-10" data-plans="" href="/docs/v71_OAuth_2">OAuth 2 Grants</a>
+<a data-released="2015-04-07" data-modified="2015-04-07" data-plans="" href="/docs/v71_OAuth2ConnectionRevokeResource">OAuth 2 Revoke</a>
+<a data-released="2014-11-22" data-modified="2014-11-22" data-plans="" href="/docs/v71_Privacy_Option">Privacy</a>
+<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="/docs/v71_User">User</a>
+<a data-released="2013-09-30" data-modified="2013-09-30" data-plans="" href="/docs/v71_User_Profile_Photo">User Profile Photo</a>
+<a data-released="2014-11-17" data-modified="2014-11-17" data-plans="" href="/docs/v71_User_Role">User Role</a>
+<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="/docs/v71_User_Stats">User Stats</a>
 
 <h5>social</h5>
-<a data-released="2014-11-18" data-modified="2014-11-18" data-plans="" href="{{ site.github.url }}/docs/v71_Activity_Story">Activity Story</a>
-<a data-released="2013-09-30" data-modified="2013-09-30" data-plans="" href="{{ site.github.url }}/docs/v71_Friendship">Friendship</a>
-<a data-released="2014-09-23" data-modified="2014-12-17" data-plans="" href="{{ site.github.url }}/docs/v71_Moderation_Action">Moderation Action</a>
-<a data-released="2014-09-23" data-modified="2014-12-17" data-plans="" href="{{ site.github.url }}/docs/v71_Moderation_Action_Type">Moderation Action Type</a>
-<a data-released="2014-09-23" data-modified="2014-12-17" data-plans="" href="{{ site.github.url }}/docs/v71_Moderation_Status">Moderation Status</a>
-<a data-released="2014-12-16" data-modified="2014-12-16" data-plans="" href="{{ site.github.url }}/docs/v71_Page">Page</a>
-<a data-released="2014-12-16" data-modified="2014-12-16" data-plans="" href="{{ site.github.url }}/docs/v71_Page_Association">Page Association</a>
-<a data-released="2014-12-16" data-modified="2014-12-16" data-plans="" href="{{ site.github.url }}/docs/v71_Page_Follow">Page Follow</a>
-<a data-released="2014-12-16" data-modified="2014-12-16" data-plans="" href="{{ site.github.url }}/docs/v71_Page_Type">Page Type</a>
-<a data-released="2014-11-17" data-modified="2014-11-17" data-plans="" href="{{ site.github.url }}/docs/v71_Role">Role</a>
-<a data-released="2014-11-22" data-modified="2014-11-22" data-plans="" href="{{ site.github.url }}/docs/v71_Suggested_Friend">Suggested Friend</a>
+<a data-released="2014-11-18" data-modified="2014-11-18" data-plans="" href="/docs/v71_Activity_Story">Activity Story</a>
+<a data-released="2013-09-30" data-modified="2013-09-30" data-plans="" href="/docs/v71_Friendship">Friendship</a>
+<a data-released="2014-09-23" data-modified="2014-12-17" data-plans="" href="/docs/v71_Moderation_Action">Moderation Action</a>
+<a data-released="2014-09-23" data-modified="2014-12-17" data-plans="" href="/docs/v71_Moderation_Action_Type">Moderation Action Type</a>
+<a data-released="2014-09-23" data-modified="2014-12-17" data-plans="" href="/docs/v71_Moderation_Status">Moderation Status</a>
+<a data-released="2014-12-16" data-modified="2014-12-16" data-plans="" href="/docs/v71_Page">Page</a>
+<a data-released="2014-12-16" data-modified="2014-12-16" data-plans="" href="/docs/v71_Page_Association">Page Association</a>
+<a data-released="2014-12-16" data-modified="2014-12-16" data-plans="" href="/docs/v71_Page_Follow">Page Follow</a>
+<a data-released="2014-12-16" data-modified="2014-12-16" data-plans="" href="/docs/v71_Page_Type">Page Type</a>
+<a data-released="2014-11-17" data-modified="2014-11-17" data-plans="" href="/docs/v71_Role">Role</a>
+<a data-released="2014-11-22" data-modified="2014-11-22" data-plans="" href="/docs/v71_Suggested_Friend">Suggested Friend</a>
 
 <h5>workouts</h5>
-<a data-released="2013-09-30" data-modified="2013-09-30" data-plans="" href="{{ site.github.url }}/docs/v71_Course" class="on">Course</a>
-<a data-released="2015-01-01" data-modified="2015-01-01" data-plans="" href="{{ site.github.url }}/docs/v71_DataSource">Data Source</a>
-<a data-released="2015-02-18" data-modified="2015-02-18" data-plans="" href="{{ site.github.url }}/docs/v71_Data_Source_Priority">Data Source Priority</a>
-<a data-released="2015-01-01" data-modified="2015-01-01" data-plans="" href="{{ site.github.url }}/docs/v71_Device">Device</a>
-<a data-released="2015-05-28" data-modified="2015-05-28" data-plans="" href="{{ site.github.url }}/docs/v71_Gear">Gear</a>
-<a data-released="2014-12-09" data-modified="2014-12-09" data-plans="" href="{{ site.github.url }}/docs/v71_Heart_Rate_Zone">Heart Rate Zone</a>
-<a data-released="2014-12-12" data-modified="2014-12-12" data-plans="" href="{{ site.github.url }}/docs/v71_Heart_Rate_Zone_Calculation">Heart Rate Zone Calculation</a>
-<a data-released="2014-10-31" data-modified="2014-10-31" data-plans="" href="{{ site.github.url }}/docs/v71_Map_Marker_Image">Map Marker Image</a>
-<a data-released="2014-12-15" data-modified="2014-12-15" data-plans="" href="{{ site.github.url }}/docs/v71_Remote_Connection">Remote Connection</a>
-<a data-released="2014-12-15" data-modified="2014-12-15" data-plans="" href="{{ site.github.url }}/docs/v71_Remote_Connection_Type">Remote Connection Type</a>
-<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="{{ site.github.url }}/docs/v71_Route">Route</a>
-<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="{{ site.github.url }}/docs/v71_Route_Bookmark">Route Bookmark</a>
-<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="{{ site.github.url }}/docs/v71_User_Achievement">User Achievement</a>
-<a data-released="2015-05-28" data-modified="2015-05-28" data-plans="" href="{{ site.github.url }}/docs/v71_User_Gear">User Gear</a>
-<a data-released="2013-10-09" data-modified="2013-10-09" data-plans="" href="{{ site.github.url }}/docs/v71_Workout">Workout</a>
-<a data-released="2014-12-09" data-modified="2014-12-09" data-plans="" href="{{ site.github.url }}/docs/v71_Workout_Heart_Rate">Workout Heart Rate</a>
+<a data-released="2013-09-30" data-modified="2013-09-30" data-plans="" href="/docs/v71_Course" class="on">Course</a>
+<a data-released="2015-01-01" data-modified="2015-01-01" data-plans="" href="/docs/v71_DataSource">Data Source</a>
+<a data-released="2015-02-18" data-modified="2015-02-18" data-plans="" href="/docs/v71_Data_Source_Priority">Data Source Priority</a>
+<a data-released="2015-01-01" data-modified="2015-01-01" data-plans="" href="/docs/v71_Device">Device</a>
+<a data-released="2015-05-28" data-modified="2015-05-28" data-plans="" href="/docs/v71_Gear">Gear</a>
+<a data-released="2014-12-09" data-modified="2014-12-09" data-plans="" href="/docs/v71_Heart_Rate_Zone">Heart Rate Zone</a>
+<a data-released="2014-12-12" data-modified="2014-12-12" data-plans="" href="/docs/v71_Heart_Rate_Zone_Calculation">Heart Rate Zone Calculation</a>
+<a data-released="2014-10-31" data-modified="2014-10-31" data-plans="" href="/docs/v71_Map_Marker_Image">Map Marker Image</a>
+<a data-released="2014-12-15" data-modified="2014-12-15" data-plans="" href="/docs/v71_Remote_Connection">Remote Connection</a>
+<a data-released="2014-12-15" data-modified="2014-12-15" data-plans="" href="/docs/v71_Remote_Connection_Type">Remote Connection Type</a>
+<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="/docs/v71_Route">Route</a>
+<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="/docs/v71_Route_Bookmark">Route Bookmark</a>
+<a data-released="2014-01-01" data-modified="2014-01-01" data-plans="" href="/docs/v71_User_Achievement">User Achievement</a>
+<a data-released="2015-05-28" data-modified="2015-05-28" data-plans="" href="/docs/v71_User_Gear">User Gear</a>
+<a data-released="2013-10-09" data-modified="2013-10-09" data-plans="" href="/docs/v71_Workout">Workout</a>
+<a data-released="2014-12-09" data-modified="2014-12-09" data-plans="" href="/docs/v71_Workout_Heart_Rate">Workout Heart Rate</a>
 
 <h5>24/7</h5>
-<a data-released="2015-03-26" data-modified="2015-03-26" data-plans="" href="{{ site.github.url }}/docs/v71_Actigraphy">Actigraphy</a>
-<a data-released="2013-09-30" data-modified="2013-09-30" data-plans="" href="{{ site.github.url }}/docs/v71_Activity_Type">Activity Type</a>
-<a data-released="2014-10-30" data-modified="2014-10-30" data-plans="" href="{{ site.github.url }}/docs/v71_Aggregate">Aggregate</a>
-<a data-released="2015-03-08" data-modified="2015-03-08" data-plans="" href="{{ site.github.url }}/docs/v71_All_Day_Activity_Time_Series">All Day Activity Time Series</a>
-<a data-released="2015-03-08" data-modified="2015-03-08" data-plans="" href="{{ site.github.url }}/docs/v71_All_Day_Activity">All Day Activity</a>
-<a data-released="2015-01-22" data-modified="2015-01-22" data-plans="" href="{{ site.github.url }}/docs/v71_BodyMass">Body Mass</a>
-<a data-released="2015-01-22" data-modified="2015-01-22" data-plans="" href="{{ site.github.url }}/docs/v71_Sleep">Sleep</a>
+<a data-released="2015-03-26" data-modified="2015-03-26" data-plans="" href="/docs/v71_Actigraphy">Actigraphy</a>
+<a data-released="2013-09-30" data-modified="2013-09-30" data-plans="" href="/docs/v71_Activity_Type">Activity Type</a>
+<a data-released="2014-10-30" data-modified="2014-10-30" data-plans="" href="/docs/v71_Aggregate">Aggregate</a>
+<a data-released="2015-03-08" data-modified="2015-03-08" data-plans="" href="/docs/v71_All_Day_Activity_Time_Series">All Day Activity Time Series</a>
+<a data-released="2015-03-08" data-modified="2015-03-08" data-plans="" href="/docs/v71_All_Day_Activity">All Day Activity</a>
+<a data-released="2015-01-22" data-modified="2015-01-22" data-plans="" href="/docs/v71_BodyMass">Body Mass</a>
+<a data-released="2015-01-22" data-modified="2015-01-22" data-plans="" href="/docs/v71_Sleep">Sleep</a>
 
 <h5>content</h5>
-<a data-released="2015-04-07" data-modified="2015-04-07" data-plans="" href="{{ site.github.url }}/docs/v71_Image">Image</a>
-<a data-released="2014-09-30" data-modified="2014-09-30" data-plans="" href="{{ site.github.url }}/docs/v71_Webhook">Webhook</a>
+<a data-released="2015-04-07" data-modified="2015-04-07" data-plans="" href="/docs/v71_Image">Image</a>
+<a data-released="2014-09-30" data-modified="2014-09-30" data-plans="" href="/docs/v71_Webhook">Webhook</a>

--- a/_posts/2015-02-02-UA-Record-Launches.md
+++ b/_posts/2015-02-02-UA-Record-Launches.md
@@ -12,16 +12,16 @@ A new feature, Personal Challenges, has also been integrated into the UA Record 
 
 Even more exciting are the features we added to our platform to build UA Record that we’re now opening up to all developers. You can find many new and updated API endpoints powering features found in UA Record, including:
 
-- [Activity Story]({{ site.github.url }}/docs/v70_Activity_Story)
-- [Moderation Action]({{ site.github.url }}/docs/v70_Moderation_Action)
-- [Moderation Action Type]({{ site.github.url }}/docs/v70_Moderation_Action_Type)
-- [Moderation Status]({{ site.github.url }}/docs/v70_Moderation_Status)
-- [Page]({{ site.github.url }}/docs/v70_Page)
-- [Page Association]({{ site.github.url }}/docs/v70_Page_Association)
-- [Page Follow]({{ site.github.url }}/docs/v70_Page_Follow)
-- [Page Type]({{ site.github.url }}/docs/v70_Page_Type)
-- [Role]({{ site.github.url }}/docs/v70_Role)
-- [User Role]({{ site.github.url }}/docs/v70_User_Role)
+- [Activity Story](/docs/v70_Activity_Story)
+- [Moderation Action](/docs/v70_Moderation_Action)
+- [Moderation Action Type](/docs/v70_Moderation_Action_Type)
+- [Moderation Status](/docs/v70_Moderation_Status)
+- [Page](/docs/v70_Page)
+- [Page Association](/docs/v70_Page_Association)
+- [Page Follow](/docs/v70_Page_Follow)
+- [Page Type](/docs/v70_Page_Type)
+- [Role](/docs/v70_Role)
+- [User Role](/docs/v70_User_Role)
 
 To try out UA Record, download the mobile app for iPhone on the [App Store](https://itunes.apple.com/us/app/under-armour-women-i-will/id895425891?mt=8) or from the [Google Play Store](https://play.google.com/store/apps/details?id=com.ua.record&hl=en). You can also visit [Record.UnderArmour.com](https://record.underarmour.com/) to set up an account or login with an existing MapMyFitness or Under Armour account.
 

--- a/_posts/2016-12-07-GET_Deprecated_on_Some_Endpoints.md
+++ b/_posts/2016-12-07-GET_Deprecated_on_Some_Endpoints.md
@@ -21,7 +21,7 @@ Your app may need to change in order to continue reading data from our API.
 
 ## Deprecated Capabilities
 
-In the endpoints enumerated above, we are deprecating the broad functionality of the collection GET method i.e. {{ site.github.url }}/docs/v71_Sleep#collection.
+In the endpoints enumerated above, we are deprecating the broad functionality of the collection GET method i.e. /docs/v71_Sleep#collection.
 Past functionality has allowed fetching any of a user’s data via the CRUD endpoints, but moving forward the only data that we can guarantee is the data created by your application.
 
 This means that only partners who are expecting to read data from sources OTHER than their own will be affected. Partners who are using the UACF platform to store data from their own app and retrieve that data back will not be affected. Any partners who are expecting to read data that was not written by ONLY their app will need to update their code as described below.
@@ -30,11 +30,11 @@ This means that only partners who are expecting to read data from sources OTHER 
 
 If your app is using the UACF Platform simply store and retrieve data, do nothing. Otherwise, if your app reads data that needs to include other providers: update your app’s code to use the /actigraphy endpoint to retrieve the data that is being written with the /sleep, /bodymass, and /activity endpoints. See the documentation for the Actigraphy endpoint here:
 
-[{{ site.github.url }}/docs/v71_Actigraphy]({{ site.github.url }}/docs/v71_Actigraphy)
+[/docs/v71_Actigraphy](/docs/v71_Actigraphy)
 
 The data that is returned for sleep and activity are governed by the user’s Data Source Priority (bodymass does not currently have a source priority):
 
-[{{ site.github.url }}/docs/v71_Data_Source_Priority]({{ site.github.url }}/docs/v71_Actigraphy).
+[/docs/v71_Data_Source_Priority](/docs/v71_Actigraphy).
 
 The Actigraphy endpoint supports GET requests on the collection, returning a document with both aggregates and metrics (time series) data for which the CRUD endpoints, and workouts are data providers.
 

--- a/docs/v71/Course.md
+++ b/docs/v71/Course.md
@@ -8,7 +8,7 @@ permalink: /docs/v71_Course/
 
 # {{ page.resource }}
 
-Returns information about {{ page.resource }}s, which are user-defined or automatically generated [Route]({{ site.github.url }}/docs/v71_Route) segments that users may travel upon during [Workouts]({{ site.github.url }}/docs/v71_Workout) and over which they may compete for various performance metrics measured over the {{ page.resource }}.
+Returns information about {{ page.resource }}s, which are user-defined or automatically generated [Route](/docs/v71_Route) segments that users may travel upon during [Workouts](/docs/v71_Workout) and over which they may compete for various performance metrics measured over the {{ page.resource }}.
 
 ## Resource URIs
 


### PR DESCRIPTION
Thanks to github/pages-gem#238, when using GitHub Pages without https enabled, `site.github.url` will contain http instead of https. This leads to mixed content warnings.